### PR TITLE
Upgrade registry-image to 1.0.0

### DIFF
--- a/Dockerfile-registry-image
+++ b/Dockerfile-registry-image
@@ -1,6 +1,6 @@
 FROM golang:1.14.3-alpine3.11 as builder
 RUN apk add git
-RUN git clone https://github.com/concourse/registry-image-resource.git /src/registry-image-resource
+RUN git clone --branch v0.14.0 https://github.com/concourse/registry-image-resource.git /src/registry-image-resource
 WORKDIR /src/registry-image-resource
 ENV CGO_ENABLED 0
 RUN go get -d ./...

--- a/resource-types/registry-image/resource_metadata.json
+++ b/resource-types/registry-image/resource_metadata.json
@@ -1,6 +1,6 @@
 {
   "type": "registry-image",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "privileged": false,
   "unique_version_history": false
 }

--- a/resource-types/registry-image/resource_metadata.json
+++ b/resource-types/registry-image/resource_metadata.json
@@ -1,6 +1,6 @@
 {
   "type": "registry-image",
-  "version": "1.0.0",
+  "version": "0.14.0",
   "privileged": false,
   "unique_version_history": false
 }


### PR DESCRIPTION
v1.0.0 is the latest available version at https://github.com/concourse/registry-image-resource/releases